### PR TITLE
feat: Implement Chrome extension for Google Calendar Meet auto-opener

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,193 @@
+// Fetches calendar events and sets alarms for upcoming meetings
+function fetchCalendarEvents(token) {
+  const timeMin = new Date().toISOString();
+  // Attempt to filter for events with Google Meet links directly in the query.
+  // We will also need to check for the 'hangoutLink' property in the response items.
+  const params = new URLSearchParams({
+    timeMin: timeMin,
+    maxResults: '10', // Consider making this configurable or fetching more
+    singleEvents: 'true',
+    orderBy: 'startTime',
+    // q: 'meet.google.com' // Keep this to pre-filter, but primary filter is hangoutLink
+  });
+  const url = `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`;
+
+  fetch(url, {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  })
+  .then(response => {
+    if (!response.ok) {
+      // If token is invalid (e.g., revoked), try to re-authenticate interactively
+      if (response.status === 401) {
+        console.warn('Authorization error (401). Attempting to re-authenticate.');
+        getAuthToken(true); // Force interactive auth
+        return Promise.reject(new Error('Token expired or revoked. Re-authentication initiated.'));
+      }
+      throw new Error(`API request failed with status ${response.status}: ${response.statusText}`);
+    }
+    return response.json();
+  })
+  .then(data => {
+    console.log('Raw calendar events:', data.items);
+    const meetEvents = (data.items || []).filter(event => 
+      event.hangoutLink && 
+      event.status !== 'cancelled' &&
+      (event.start.dateTime || event.start.date) // Ensure there's a start time
+    );
+
+    console.log('Events with Google Meet links after filtering:', meetEvents);
+
+    chrome.storage.sync.get({ reminderMinutes: 0 }, (settings) => { // Default to 0 minutes
+      const reminderOffsetMs = settings.reminderMinutes * 60 * 1000;
+      console.log(`Using reminder offset: ${settings.reminderMinutes} minutes (${reminderOffsetMs}ms)`);
+
+      meetEvents.forEach(event => {
+        try {
+          const eventStartTimeMs = new Date(event.start.dateTime || event.start.date).getTime();
+          const currentTimeMs = Date.now();
+          const alarmName = `gmeet-opener-meeting-${event.id}`; // Using the prefix from previous step
+
+          // Calculate when the reminder alarm should ideally fire
+          let intendedAlarmTimeMs = eventStartTimeMs - reminderOffsetMs;
+
+          // Only schedule if the original meeting start time is in the future
+          if (eventStartTimeMs > currentTimeMs) {
+            // If the calculated reminder time is now or in the past,
+            // but the meeting is still in the future, schedule it to open ASAP (e.g., in a few seconds).
+            // Otherwise, use the calculated reminder time.
+            const scheduleTimeMs = Math.max(currentTimeMs + 2000, intendedAlarmTimeMs); // At least 2s in future
+
+            chrome.storage.local.set({
+              [alarmName]: {
+                meetLink: event.hangoutLink,
+                title: event.summary || 'Untitled Meeting',
+                startTime: eventStartTimeMs,
+                // Store the intended opening time based on reminder for clarity if needed
+                intendedOpenTime: intendedAlarmTimeMs 
+              }
+            }, () => {
+              if (chrome.runtime.lastError) {
+                console.error(`Error saving meeting details for alarm ${alarmName}:`, chrome.runtime.lastError.message);
+                return;
+              }
+              chrome.alarms.create(alarmName, { when: scheduleTimeMs });
+              console.log(`Alarm set for "${event.summary || 'Untitled Meeting'}" - scheduled at ${new Date(scheduleTimeMs).toLocaleString()} (meeting at ${new Date(eventStartTimeMs).toLocaleString()})`);
+            });
+          } else {
+            // console.log(`Event "${event.summary || 'Untitled Meeting'}" (ID: ${event.id}) is in the past. Not scheduling.`);
+          }
+        } catch (e) {
+          console.error(`Error processing event ${event.id} ("${event.summary || 'Untitled Meeting'}") for alarm scheduling:`, e);
+        }
+      });
+    });
+  })
+  .catch(error => {
+    // This will catch errors from the fetch itself, or if .json() fails.
+    // Errors inside the .then() before the forEach, or within sync.get's callback if not handled, might not be caught here.
+    console.error('Error fetching calendar events or initial processing:', error.message);
+  });
+}
+
+// Handles OAuth token retrieval
+function getAuthToken(interactive = true) {
+  chrome.identity.getAuthToken({ interactive: interactive }, function(token) {
+    if (chrome.runtime.lastError) {
+      console.error('Error getting auth token:', chrome.runtime.lastError.message);
+      // Example: If non-interactive fails, maybe notify user or disable functionality
+      // For now, we just log it.
+      return;
+    }
+    console.log('Successfully obtained OAuth token.');
+    fetchCalendarEvents(token);
+  });
+}
+
+// Alarm Listener
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  console.log('Alarm fired:', alarm.name);
+
+  if (alarm.name === 'fetchCalendarDataPeriodic') { // Updated alarm name for clarity
+    console.log('Periodic alarm: Fetching new calendar data...');
+    getAuthToken(false); // Non-interactive
+  } else if (alarm.name.startsWith('gmeet-opener-meeting-')) {
+    chrome.storage.local.get(alarm.name, (result) => {
+      if (chrome.runtime.lastError) {
+        console.error('Error retrieving meeting data from storage for alarm', alarm.name, ':', chrome.runtime.lastError.message);
+        return;
+      }
+      const meetingData = result[alarm.name];
+      if (meetingData && meetingData.meetLink) {
+        console.log(`Opening Meet link for "${meetingData.title}" (alarm: ${alarm.name}): ${meetingData.meetLink}`);
+        chrome.tabs.create({ url: meetingData.meetLink });
+        
+        // Clean up the storage for this meeting
+        chrome.storage.local.remove(alarm.name, () => {
+          if (chrome.runtime.lastError) {
+            console.error('Error removing meeting data from storage for alarm', alarm.name, ':', chrome.runtime.lastError.message);
+          } else {
+            console.log(`Cleaned up storage for alarm ${alarm.name}`);
+          }
+        });
+      } else {
+        console.warn(`No meeting data found for alarm ${alarm.name}. It might have been processed, data was not stored, or an error occurred.`);
+      }
+    });
+  }
+});
+
+// Setup periodic fetching
+function setupPeriodicFetch() {
+  const alarmName = 'fetchCalendarDataPeriodic'; // Consistent naming
+  // Check if alarm already exists to avoid duplicates or resetting its schedule unnecessarily
+  chrome.alarms.get(alarmName, (existingAlarm) => {
+    if (existingAlarm) {
+      console.log(`Periodic fetch alarm "${alarmName}" already exists. Scheduled for ${new Date(existingAlarm.scheduledTime).toLocaleString()}`);
+    } else {
+      console.log(`Setting up periodic calendar data fetch alarm "${alarmName}" (every 60 minutes, starting in 1 min).`);
+      chrome.alarms.create(alarmName, {
+        delayInMinutes: 1, // Start after 1 minute
+        periodInMinutes: 60 // Repeat every 60 minutes
+      });
+    }
+  });
+}
+
+// Extension lifecycle event listeners
+chrome.runtime.onInstalled.addListener((details) => {
+  console.log('Extension installed:', details.reason);
+  // On first install, clear any potentially stale alarms or storage from previous dev versions
+  if (details.reason === 'install') {
+    console.log('First install. Clearing all alarms and storage.');
+    chrome.alarms.getAll(alarms => {
+        alarms.forEach(alarm => {
+            if (alarm.name.startsWith('gmeet-opener-') || alarm.name === 'fetchCalendarDataPeriodic') {
+                chrome.alarms.clear(alarm.name);
+            }
+        });
+    });
+    chrome.storage.local.clear(() => {
+        console.log('Storage cleared on first install.');
+        // Now proceed with initial setup
+        getAuthToken(true); // Initial auth & fetch
+        setupPeriodicFetch();
+    });
+  } else if (details.reason === 'update') {
+    console.log('Extension updated to version', chrome.runtime.getManifest().version);
+    // Potentially handle updates, like migrating storage or re-setting alarms
+    getAuthToken(false); // Fetch on update
+    setupPeriodicFetch(); // Ensure periodic fetch is still scheduled
+  }
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  console.log('Browser startup.');
+  // Ensure periodic alarm is set (it might have been cleared if browser crashed or was force-quit)
+  setupPeriodicFetch(); // This function now checks if alarm already exists
+  // Initial fetch on startup as well
+  getAuthToken(false); 
+});
+
+console.log("Background script loaded and listeners registered."); // Helps confirm script is running

--- a/images/icon128.png
+++ b/images/icon128.png
@@ -1,0 +1,1 @@
+placeholder icon 128x128

--- a/images/icon16.png
+++ b/images/icon16.png
@@ -1,0 +1,1 @@
+placeholder icon 16x16

--- a/images/icon48.png
+++ b/images/icon48.png
@@ -1,0 +1,1 @@
+placeholder icon 48x48

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Google Meet Auto-Opener",
+  "version": "1.0",
+  "description": "Automatically opens Google Meet links from your Google Calendar events.",
+  "permissions": [
+    "identity",
+    "storage",
+    "alarms",
+    "https://www.googleapis.com/calendar/v3/"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html",
+  "icons": {
+    "16": "images/icon16.png",
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
+  }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Google Meet Auto-Opener Options</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; max-width: 400px; margin: auto; }
+    label { display: block; margin-bottom: 5px; }
+    input[type="number"] { width: 60px; padding: 5px; margin-bottom: 15px; }
+    button { padding: 8px 15px; cursor: pointer; }
+    #status { margin-top: 15px; font-style: italic; }
+  </style>
+</head>
+<body>
+  <h1>Google Meet Auto-Opener Options</h1>
+  
+  <div>
+    <label for="reminderTime">Open meeting tab (minutes before start):</label>
+    <input type="number" id="reminderTime" name="reminderTime" min="0" max="60" value="5">
+  </div>
+  
+  <button id="save">Save Settings</button>
+  <div id="status"></div>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,28 @@
+// Saves options to chrome.storage.sync.
+function save_options() {
+  const reminderTime = document.getElementById('reminderTime').value;
+  chrome.storage.sync.set({
+    reminderMinutes: parseInt(reminderTime, 10)
+  }, function() {
+    // Update status to let user know options were saved.
+    const status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 1000);
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.sync.
+function restore_options() {
+  // Default to 5 minutes if nothing is set.
+  chrome.storage.sync.get({
+    reminderMinutes: 5 
+  }, function(items) {
+    document.getElementById('reminderTime').value = items.reminderMinutes;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);


### PR DESCRIPTION
This commit introduces a Chrome extension that connects to your Google Calendar and automatically opens Google Meet links when meetings are about to start.

Key Features:
- OAuth 2.0 for secure Google Calendar authentication.
- Fetches upcoming calendar events and identifies those with Google Meet links.
- Uses `chrome.alarms` to schedule opening of Meet links.
- You can configure a reminder time (minutes before the meeting) via an options page, determining when the Meet tab is opened. This setting is synced across devices using `chrome.storage.sync`.
- A background script handles all core logic, including periodic fetching of calendar data to keep events updated.
- Placeholder icons and a basic options page UI are included.

The extension structure includes:
- `manifest.json`: Defines permissions (identity, storage, alarms, Google Calendar API), background service, options page, and icons.
- `background.js`: Handles authentication, API communication, event processing, alarm management, and tab opening.
- `options.html` & `options.js`: Provide a user interface for settings.
- `images/`: Contains placeholder icons.

This resolves the issue of converting the previous web application concept into a functional Chrome extension with the requested capabilities.