### PR TITLE
Alright, I've configured the project to use a developer-provided OAut…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,76 @@ This Chrome extension automatically opens Google Meet links from your upcoming G
     *   Click the "Load unpacked" button.
     *   In the file dialog that appears, select the directory where you cloned or downloaded the extension files (e.g., the `google-meet-auto-opener` directory).
 
+## Configuration: Setting up Google Calendar API Access
+
+To enable the extension to access your Google Calendar, you need to set up an OAuth 2.0 Client ID. Follow these steps:
+
+1.  **Go to Google Cloud Console:**
+    Open your web browser and navigate to the [Google Cloud Console](https://console.cloud.google.com/).
+
+2.  **Create or Select a Project:**
+    *   If you don't have a project, create a new one by clicking the project selector at the top of the page and then "NEW PROJECT". Follow the on-screen instructions.
+    *   If you have an existing project, select it from the project selector.
+
+3.  **Enable Google Calendar API:**
+    *   In the navigation menu (usually a hamburger icon ☰ on the left), go to "APIs & Services" > "Library".
+    *   In the search bar, type "Google Calendar API" and press Enter.
+    *   Click on "Google Calendar API" from the search results.
+    *   Click the "Enable" button if it's not already enabled.
+
+4.  **Navigate to Credentials:**
+    *   In the navigation menu, go to "APIs & Services" > "Credentials".
+
+5.  **Create OAuth Client ID:**
+    *   Click the "+ CREATE CREDENTIALS" button at the top of the page.
+    *   Select "OAuth client ID" from the dropdown menu.
+
+6.  **Configure OAuth Consent Screen (if needed):**
+    *   If you haven't configured the OAuth consent screen for this project, you'll be prompted to do so. Click "CONFIGURE CONSENT SCREEN".
+    *   **User Type:** Choose "External" if you want users outside your organization to use this (common for personal projects or public extensions). Choose "Internal" if this is only for users within your Google Workspace organization.
+    *   **App information:**
+        *   **App name:** Enter a descriptive name (e.g., "Google Meet Auto-Opener Extension").
+        *   **User support email:** Select your email address.
+        *   **Developer contact information:** Enter your email address.
+    *   Click "SAVE AND CONTINUE" through the "Scopes" and "Test users" sections (you don't need to add scopes or test users here; the extension will request scopes itself).
+    *   Finally, click "BACK TO DASHBOARD" on the "Summary" page.
+    *   You might need to go back to "APIs & Services" > "Credentials" and click "+ CREATE CREDENTIALS" > "OAuth client ID" again.
+
+7.  **Create the OAuth Client ID for the Chrome Extension:**
+    *   **Application type:** Select "Chrome App" from the dropdown.
+    *   **Name:** Give your OAuth client ID a name (e.g., "Meet Auto-Opener Client").
+    *   **Application ID:** This is crucial. You need to enter your Chrome Extension's ID here.
+        *   To find your Extension ID:
+            1.  Make sure you have loaded the extension into Chrome using the "Load unpacked" method described in the "How to Install/Load" section above.
+            2.  Go to `chrome://extensions`.
+            3.  Find your "Google Meet Auto-Opener" extension in the list.
+            4.  The ID will be a long string of characters (e.g., `abcdefghijklmnopabcdefghijklmnop`). Copy this ID.
+        *   Paste the copied Extension ID into the "Application ID" field in the Google Cloud Console.
+    *   Click "CREATE".
+
+8.  **Copy Your Client ID:**
+    *   After successful creation, a dialog box will appear showing "Your Client ID".
+    *   Copy this Client ID (it will look something like `YOUR_LONG_CLIENT_ID.apps.googleusercontent.com`).
+
+9.  **Update `manifest.json`:**
+    *   Open the `manifest.json` file located in your extension's directory.
+    *   Find the `oauth2` section:
+        ```json
+        "oauth2": {
+          "client_id": "YOUR_CLIENT_ID_HERE",
+          "scopes": [
+            "https://www.googleapis.com/auth/calendar.events.readonly"
+          ]
+        }
+        ```
+    *   Replace the placeholder `"YOUR_CLIENT_ID_HERE"` with the actual Client ID you copied from the Google Cloud Console.
+    *   Save the `manifest.json` file.
+
+After completing these steps and reloading your extension in `chrome://extensions` (if it was already loaded), it should be able to authenticate and access your Google Calendar events.
+
 ## Usage
 1.  **Grant Permissions:**
-    *   After installation, the extension might prompt you for permission to access your Google Calendar data when it first tries to fetch events, or you might need to trigger this by opening its options page. Ensure you grant the necessary permissions for it to function correctly.
+    *   After installation and configuration, the extension will prompt you for permission to access your Google Calendar data when it first tries to fetch events. Ensure you grant the necessary permissions.
 
 2.  **Configure Reminder Time:**
     *   Click on the extension's icon in the Chrome toolbar (you might need to pin it first from the puzzle-piece extensions menu).

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,7 @@
   "permissions": [
     "identity",
     "storage",
-    "alarms",
-    "https://www.googleapis.com/calendar/v3/"
+    "alarms"
   ],
   "background": {
     "service_worker": "background.js"
@@ -15,5 +14,11 @@
   "options_page": "options.html",
   "icons": {
     "128": "128.png"
+  },
+  "oauth2": {
+    "client_id": "YOUR_CLIENT_ID_HERE",
+    "scopes": [
+      "https://www.googleapis.com/auth/calendar.events.readonly"
+    ]
   }
 }


### PR DESCRIPTION
…h2 Client ID.

Here's a breakdown of the project structure I've set up:

1.  The `manifest.json` file is now set up to use an OAuth2 Client ID for accessing the Google Calendar API. It includes a placeholder for the `client_id` and specifies the necessary `calendar.events.readonly` scope.
2.  The `README.md` file contains detailed instructions to help you:
    *   Create a Google Cloud Project.
    *   Enable the Google Calendar API.
    *   Obtain an OAuth 2.0 Client ID (specifically for a Chrome App, using your extension's ID).
    *   Insert this Client ID into the `manifest.json` file.

This setup ensures that your extension can correctly authenticate with the Google Calendar API once you configure your specific Client ID by following the instructions in the README. This should resolve the "Permission unknown" and "Invalid OAuth2 Client ID" errors you were encountering.